### PR TITLE
Added support for other source file extensions

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,5 @@
+* Added support for other source file extensions.
+
 * `inst` directory not automatically created.  (Fixes #53)
 
 * Explicitly depends on `utils` and `methods` packages to make roxygen more

--- a/R/roclet-rd.R
+++ b/R/roclet-rd.R
@@ -225,7 +225,7 @@ rd_roclet <- function() {
 roc_process.had <- function(roclet, partita, base_path) {
   # Remove srcrefs with no attached roxygen comments
   partita <- Filter(function(x) length(x) > 1, partita)
-  templates <- dir(file.path(base_path, "max-roxygen"), full = TRUE)
+  templates <- dir(file.path(base_path, "max-roxygen"), full.names = TRUE)
   template_hash <- digest(lapply(templates, readLines))
   
   topics <- list()

--- a/R/roxygenize.R
+++ b/R/roxygenize.R
@@ -13,6 +13,7 @@
 #'    files.
 #' @param overwrite overwrite target files?
 #' @param unlink.target unlink target directory before processing files?
+#' @param file.ext extension of source files to be processed
 #' @param roclets character vector of roclet names to apply to package
 #' @return \code{NULL}
 #' @rdname roxygenize
@@ -22,6 +23,7 @@ roxygenize <- function(package.dir,
                        copy.package=package.dir != roxygen.dir,
                        overwrite=TRUE,
                        unlink.target=FALSE,
+                       file.ext = "[.Rr]",
                        roclets=c("collate", "namespace", "rd")) {
 
   skeleton <- c(roxygen.dir, file.path(roxygen.dir, "man"))
@@ -36,7 +38,7 @@ roxygenize <- function(package.dir,
   }
 
   roxygen.dir <- normalizePath(roxygen.dir)
-  r_files <- dir(file.path(roxygen.dir, "R"), "[.Rr]$", full.names = TRUE)
+  r_files <- dir(file.path(roxygen.dir, "R"), paste0(file.ext, "$"), full.names = TRUE)
 
   # If description present, use Collate to order the files 
   # (but still include them all, and silently remove missing)

--- a/R/roxygenize.R
+++ b/R/roxygenize.R
@@ -88,7 +88,7 @@ copy.dir <- function(source,
   if (unlink.target)
     unlink(target, recursive=TRUE)
   files <- list.files(source,
-                      full.name=TRUE,
+                      full.names=TRUE,
                       recursive=TRUE,
                       all.files=TRUE)
   for (source.file in files) {

--- a/R/template.R
+++ b/R/template.R
@@ -13,7 +13,7 @@ template_find <- function(base_path, template_name) {
 
 #' @importFrom brew brew
 template_eval <- function(template_path, vars) {
-  capture.output(brew(template_path, env = vars))
+  capture.output(brew(template_path, envir = vars))
 }
 
 process_templates <- function(partitum, base_path) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -15,7 +15,7 @@ usage <- function(args) {
   arg_to_text <- function(arg) {
     if (is.missing.arg(arg)) return("")
     text <- deparse(arg, backtick = TRUE, width.cutoff = 500L)
-    text <- str_replace_all(text, fixed("%"), "\\%")
+    text <- str_replace_all(text, "([%\\])", "\\\\\\1")
     text <- str_replace_all(text, fixed(" "), "\u{A0}")
     Encoding(text) <- "UTF-8"    
     

--- a/inst/tests/test-rd-usage.R
+++ b/inst/tests/test-rd-usage.R
@@ -24,11 +24,11 @@ test_that("usage correct for functions with no arguments", {
   expect_equal(get_tag(out, "usage")$values, "f()")
 })
 
-test_that("% is escaped in usage", {
+test_that("% and \\ are escaped in usage", {
   out <- roc_proc_text(roc, "
     #' Title.
-    a <- function(a='%') {}")[[1]]
-  expect_equal(get_tag(out, "usage")$values, "a(a\u{A0}=\u{A0}\"\\%\")")
+    a <- function(a='%\\\\') {}")[[1]]
+  expect_equal(get_tag(out, "usage")$values, 'a(a\u{A0}=\u{A0}"\\%\\\\\\\\")')
 })
 
 test_that("long usages protected from incorrect breakage", {

--- a/man/roxygenize.Rd
+++ b/man/roxygenize.Rd
@@ -6,11 +6,13 @@
   roxygenize(package.dir, roxygen.dir = package.dir,
     copy.package = package.dir != roxygen.dir,
     overwrite = TRUE, unlink.target = FALSE,
+    file.ext = "[.Rr]",
     roclets = c("collate", "namespace", "rd"))
 
   roxygenise(package.dir, roxygen.dir = package.dir,
     copy.package = package.dir != roxygen.dir,
     overwrite = TRUE, unlink.target = FALSE,
+    file.ext = "[.Rr]",
     roclets = c("collate", "namespace", "rd"))
 }
 \arguments{
@@ -26,6 +28,9 @@
 
   \item{unlink.target}{unlink target directory before
   processing files?}
+
+  \item{file.ext}{extension of source files to be
+  processed}
 
   \item{roclets}{character vector of roclet names to apply
   to package}


### PR DESCRIPTION
The proposed changes add support for other source file extension by introducing an argument `file.ext` to the function `roxygenize`. The specific use case is to allow usage of roxygen2 with other S language dialects and as such to parse file extensions such as ".q", ".S" and ".s".
